### PR TITLE
Add SetupFakeDbSet(), Add() and AddRange() extension methods

### DIFF
--- a/Examples/Example.BusinessLogicTest/DataAccessTest.cs
+++ b/Examples/Example.BusinessLogicTest/DataAccessTest.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
+using FakeDbSet;
 using NUnit.Framework;
 using Example.BusinessLogic;
 using Example.Data;
@@ -35,5 +35,57 @@ namespace Example.BusinessLogicTest
 			Assert.That(books.Count, Is.EqualTo(1));
 			Assert.That(books.First().Author.LastName, Is.EqualTo("Last Name 2"));
 		}
+
+        [Test]
+        public void Setup_fake_dbset_returns_expected()
+        {
+            // Arrange
+            var entities = new BookStoreEntities();
+            var book = new Book { Title = "title" };
+
+            // Act
+            entities.SetupFakeDbSet(x => x.Books).Add(book);
+
+            // Assert
+            Assert.That(entities.Books.Count(), Is.EqualTo(1));
+            Assert.That(entities.Books.First().Title, Is.EqualTo("title"));
+        }
+
+        [Test]
+        public void Setup_fake_dbset_with_add_range_returns_expected()
+        {
+            // Arrange
+            var entities = new BookStoreEntities();
+            var books = new []
+            {
+                new Book { Title = "title 1" },
+                new Book { Title = "title 2" }
+            };
+
+            // Act
+            entities.SetupFakeDbSet(x => x.Books).AddRange(books);
+
+            // Assert
+            Assert.That(entities.Books.Count(), Is.EqualTo(2));
+            Assert.That(entities.Books.First().Title, Is.EqualTo("title 1"));
+            Assert.That(entities.Books.Last().Title, Is.EqualTo("title 2"));
+        }
+
+        [Test]
+        public void Setup_fake_dbset_with_add_many_returns_expected()
+        {
+            // Arrange
+            var entities = new BookStoreEntities();
+            var book1 = new Book { Title = "title 1" };
+            var book2 = new Book { Title = "title 2" };
+
+            // Act
+            entities.SetupFakeDbSet(x => x.Books).Add(book1, book2);
+
+            // Assert
+            Assert.That(entities.Books.Count(), Is.EqualTo(2));
+            Assert.That(entities.Books.First().Title, Is.EqualTo("title 1"));
+            Assert.That(entities.Books.Last().Title, Is.EqualTo("title 2"));
+        }
 	}
 }

--- a/FakeDbSet/DbContextExtensions.cs
+++ b/FakeDbSet/DbContextExtensions.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Data.Entity;
+using System.Linq.Expressions;
+using System.Reflection;
+
+namespace FakeDbSet
+{
+    public static class DbContextExtensions
+    {
+        /// <summary>
+        /// Sets up a fake IDbSet.
+        /// </summary>
+        /// <typeparam name="TEntity"></typeparam>
+        /// <typeparam name="TDbContext"></typeparam>
+        /// <param name="dbContext">The DbContext containing the IDbSet to setup.</param>
+        /// <param name="expression">The IDbSet to setup.</param>
+        /// <returns></returns>
+        public static IDbSet<TEntity> SetupFakeDbSet<TEntity, TDbContext>(this TDbContext dbContext, Expression<Func<TDbContext, IDbSet<TEntity>>> expression) where TEntity : class
+        {
+            var dbSet = new InMemoryDbSet<TEntity>();
+            
+            var member = expression.Body as MemberExpression;
+            if (member == null)
+            {
+                throw new ArgumentException(String.Format("Expression '{0}' refers to a method, not a property.", expression));
+            }
+
+            var propInfo = member.Member as PropertyInfo;
+            if (propInfo == null)
+            {
+                throw new ArgumentException(String.Format("Expression '{0}' refers to a field, not a property.", expression));
+            }
+
+            propInfo.SetValue(dbContext, dbSet);
+
+            return dbSet;
+        }
+    }
+}

--- a/FakeDbSet/FakeDbSet.csproj
+++ b/FakeDbSet/FakeDbSet.csproj
@@ -48,7 +48,9 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DbContextExtensions.cs" />
     <Compile Include="DbSetHelper.cs" />
+    <Compile Include="IDbSetExtensions.cs" />
     <Compile Include="InMemoryDbSet.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>

--- a/FakeDbSet/IDbSetExtensions.cs
+++ b/FakeDbSet/IDbSetExtensions.cs
@@ -1,0 +1,21 @@
+﻿using System.Collections.Generic;
+using System.Data.Entity;
+
+namespace FakeDbSet
+{
+    public static class IDbSetExtensions
+    {
+        public static void AddRange<T>(this IDbSet<T> dbSet, IEnumerable<T> items) where T : class
+        {
+            foreach (var item in items)
+            {
+                dbSet.Add(item);
+            }
+        }
+
+        public static void Add<T>(this IDbSet<T> dbSet, params T[] items) where T : class
+        {
+            dbSet.AddRange(items);
+        }
+    }
+}


### PR DESCRIPTION
I've added a `SetupFakeDbSet()` method to make setting up an `IDbSet` easy in a unit test.  It's fluent so it can be used like this:

``` csharp
entities.SetupFakeDbSet(x => x.Books).Add(book);
```

It can also be used like this with the new `Add()` and `AddRange()` extension methods:

``` csharp
entities.SetupFakeDbSet(x => x.Books).Add(book1, book2);
entities.SetupFakeDbSet(x => x.Books).AddRange(books);
```

I would have raised an issue first, but you seem to have issues switched off on this repro.
